### PR TITLE
Refactor/html accessibility

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
   <body>
     <header>
       <h1><span id='header-name'></span>FITLIT</h1>
-      <button type='button' name='button' id='profile-button' aria-label='Expand User Profile Information'></button>
+      <button name='button' id='profile-button' aria-label='Expand User Profile Information'></button>
       <section class='hide' id='user-info-dropdown' aria-expanded='false'>
         <h5 id='dropdown-name'></h5>
         <p class='dropdown-p' id='dropdown-email'></p>
@@ -23,21 +23,21 @@
       <section class='card-container' id='steps-card-container'>
         <section class='main-card' id='steps-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button steps-info-button' aria-label='Open User Steps Information'>
+            <button name='button' class='info-button steps-info-button' aria-label='Open User Steps Information'>
             </button> 
             <h3>YOU HAVE WALKED</h3>
-            <button type='button' name='button' class='friends-button steps-friends-button' aria-label='Open Friends Step Information'>
+            <button name='button' class='friends-button steps-friends-button' aria-label='Open Friends Step Information'>
             </button>
           </div>
           <h2 id='steps-user-steps-today'>X</h2>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='trending-button steps-trending-button' aria-label='Open Trending Step Information'></button>
+            <button name='button' class='trending-button steps-trending-button' aria-label='Open Trending Step Information'></button>
             <h3>STEPS TODAY</h3>
-            <button type='button' name='button' class='calendar-button steps-calendar-button' aria-label='Open Calendar'></button>></button>
+            <button name='button' class='calendar-button steps-calendar-button' aria-label='Open Calendar'></button>></button>
           </div>
         </section>
         <section class='info-card hide' id='steps-info-card'>
-          <button type='button' name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'>
+          <button name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'>
           </button>
           <div class='card-data-line'>
             <p>TOTAL ACTIVE MINUTES TODAY:</p>
@@ -49,7 +49,7 @@
           </div>
         </section>
         <section class='friends-card hide' id='steps-friends-card'>
-          <button type='button' name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
+          <button name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
           <div class='card-data-line'>
             <p>ALL USERS' AVERAGE ACTIVE MINUTES TODAY:</p>
             <h4 id='steps-friend-active-minutes-average-today'></h4>
@@ -68,12 +68,12 @@
           </div>
         </section>
         <section class='trending-card hide' id='steps-trending-card'>
-          <button type='button' name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
+          <button name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
           <div class='card-data-line trending-steps-phrase-container'>
           </div>
         </section>
         <section class='calendar-card hide' id='steps-calendar-card'>
-          <button type='button' name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
+          <button name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
           <div class='card-data-line'>
             <p>YOUR WEEKLY AVERAGE MINUTES:</p>
             <h4 id='steps-calendar-total-active-minutes-weekly'></h4>
@@ -87,19 +87,19 @@
       <section class='card-container hydration' id='hydration-card-container'>
         <section class='main-card' id='hydration-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button hydration-info-button' aria-label='Open Users Hydration Information'></button>
+            <button name='button' class='info-button hydration-info-button' aria-label='Open Users Hydration Information'></button>
             <h3>YOU HAVE HAD</h3>
-            <button type='button' name='button' class='friends-button hydration-friends-button' aria-label='Open Friends Hydration Information'></button>
+            <button name='button' class='friends-button hydration-friends-button' aria-label='Open Friends Hydration Information'></button>
           </div>
           <h2 id='hydration-user-ounces-today'></h2>
           <div class='main-card-bottom-row'>
             <h3>OZ OF WATER TODAY</h3>
-            <button type='button' name='button' class='calendar-button hydration-calendar-button' aria-label='Open Hydration Calendar'> 
+            <button name='button' class='calendar-button hydration-calendar-button' aria-label='Open Hydration Calendar'> 
             </button>
           </div>
         </section>
         <section class='info-card hide' id='hydration-info-card'>
-          <button type='button' name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'> 
+          <button name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'> 
             </button>
           <div class='card-data-line'>
             <p>GLASSES OF WATER CONSUMED TODAY:</p>
@@ -107,14 +107,14 @@
           </div>
         </section>
         <section class='friends-card hide' id='hydration-friends-card'>
-          <button type='button' name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>ALL USERS' AVERAGE DAILY OUNCES:</p>
             <h4 id='hydration-friend-ounces-today'></h4>
           </div>
         </section>
         <section class='calendar-card hide' id='hydration-calendar-card'>
-          <button type='button' name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='hydration-data-line'>
             <p class='hydration-weekly-label'>YESTERDAY:</p>
             <h4 class='hydration-weekly-amount'><span class='daily-oz' id='hydration-calendar-ounces-1day'></span> oz</h4>
@@ -144,38 +144,38 @@
       <section class='card-container' id='stairs-card-container'>
         <section class='main-card' id='stairs-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button stairs-info-button' aria-label='Open Users Stair Count Information'></button>
+            <button name='button' class='info-button stairs-info-button' aria-label='Open Users Stair Count Information'></button>
             <h3>YOU HAVE CLIMBED</h3>
-            <button type='button' name='button' class='friends-button stairs-friends-button' aria-label='Open Friends Stair Count Information'></button>
+            <button name='button' class='friends-button stairs-friends-button' aria-label='Open Friends Stair Count Information'></button>
           </div>
           <h2 id='stairs-user-stairs-today'></h2>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='trending-button stairs-trending-button' aria-label='Open Trending Stair Count Information'></button>
+            <button name='button' class='trending-button stairs-trending-button' aria-label='Open Trending Stair Count Information'></button>
             <h3>STAIRS TODAY</h3>
-            <button type='button' name='button' class='calendar-button stairs-calendar-button' aria-label='Open Calendar'></button>
+            <button name='button' class='calendar-button stairs-calendar-button' aria-label='Open Calendar'></button>
           </div>
         </section>
         <section class='info-card hide' id='stairs-info-card'>
-          <button type='button' name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>FLIGHTS CLIMBED TODAY</p>
             <h4 id='stairs-info-flights-today'></h4>
           </div>
         </section>
         <section class='friends-card hide' id='stairs-friends-card'>
-          <button type='button' name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>ALL USERS' AVERAGE FLIGHTS TODAY</p>
             <h4 id='stairs-friend-flights-average-today'></h4>
           </div>
         </section>
         <section class='trending-card hide' id='stairs-trending-card'>
-          <button type='button' name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line trending-stairs-phrase-container'>
           </div>
         </section>
         <section class='calendar-card hide' id='stairs-calendar-card'>
-          <button type='button' name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>YOUR WEEKLY FLIGHTS CLIMBED</p>
             <h4 id='stairs-calendar-flights-average-weekly'></h4>
@@ -189,20 +189,20 @@
       <section class='card-container' id='sleep-card-container'>
         <section class='main-card' id='sleep-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button sleep-info-button' aria-label='Open Users Sleep Information'>
+            <button name='button' class='info-button sleep-info-button' aria-label='Open Users Sleep Information'>
             </button>
             <h3>YOU SLEPT</h3>
-            <button type='button' name='button' class='friends-button sleep-friends-button' aria-label='Open Friends Sleep Information'>
+            <button name='button' class='friends-button sleep-friends-button' aria-label='Open Friends Sleep Information'>
             </button>
           </div>
           <h2 id='sleep-user-hours-today'></h2>
           <div class='main-card-bottom-row'>
             <h3>HOURS LAST NIGHT</h3>
-            <button type='button' name='button' class='calendar-button sleep-calendar-button' aria-label='Open Sleep Calendar'></button>
+            <button name='button' class='calendar-button sleep-calendar-button' aria-label='Open Sleep Calendar'></button>
           </div>
         </section>
         <section class='info-card hide' id='sleep-info-card'>
-          <button type='button' name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>SLEEP QUALITY LAST NIGHT</p>
             <h4 id='sleep-info-quality-today'></h4>
@@ -217,7 +217,7 @@
           </div>
         </section>
         <section class='friends-card hide' id='sleep-friends-card'>
-          <button type='button' name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>LAST NIGHT'S SUPERIOR SLEEPER</p>
             <h4 id='sleep-friend-longest-sleeper'></h4>
@@ -228,7 +228,7 @@
           </div>
         </section>
         <section class='calendar-card hide' id='sleep-calendar-card'>
-          <button type='button' name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
+          <button name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>LAST WEEK'S HOURLY AVERAGE</p>
             <h4 id='sleep-calendar-hours-average-weekly'></h4>

--- a/src/index.html
+++ b/src/index.html
@@ -9,8 +9,8 @@
   <body>
     <header>
       <h1><span id='header-name'></span>FITLIT</h1>
-      <button type='button' name='button' id='profile-button'></button>
-      <section class='hide' id='user-info-dropdown'>
+      <button type='button' name='button' id='profile-button' aria-label='Expand User Profile Information'></button>
+      <section class='hide' id='user-info-dropdown' aria-expanded='false'>
         <h5 id='dropdown-name'></h5>
         <p class='dropdown-p' id='dropdown-email'></p>
         <p class='dropdown-p' id='dropdown-goal'></p>
@@ -23,20 +23,22 @@
       <section class='card-container' id='steps-card-container'>
         <section class='main-card' id='steps-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button steps-info-button' aria-label='View User Steps Information' aria-hidden='true'></button> 
-            <!-- aria not working on button above or below  -->
+            <button type='button' name='button' class='info-button steps-info-button' aria-label='Open User Steps Information'>
+            </button> 
             <h3>YOU HAVE WALKED</h3>
-            <button type='button' name='button' class='friends-button steps-friends-button' aria-label='View Friends Step Button' aria-hidden='true'></button>
+            <button type='button' name='button' class='friends-button steps-friends-button' aria-label='Open Friends Step Information'>
+            </button>
           </div>
           <h2 id='steps-user-steps-today'>X</h2>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='trending-button steps-trending-button'></button>
+            <button type='button' name='button' class='trending-button steps-trending-button' aria-label='Open Trending Step Information'></button>
             <h3>STEPS TODAY</h3>
-            <button type='button' name='button' class='calendar-button steps-calendar-button'></button>
+            <button type='button' name='button' class='calendar-button steps-calendar-button' aria-label='Open Calendar'></button>></button>
           </div>
         </section>
         <section class='info-card hide' id='steps-info-card'>
-          <button type='button' name='button' class='go-back-button steps-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'>
+          </button>
           <div class='card-data-line'>
             <p>TOTAL ACTIVE MINUTES TODAY:</p>
             <h4 id='steps-info-active-minutes-today'></h4>
@@ -47,7 +49,7 @@
           </div>
         </section>
         <section class='friends-card hide' id='steps-friends-card'>
-          <button type='button' name='button' class='go-back-button steps-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
           <div class='card-data-line'>
             <p>ALL USERS' AVERAGE ACTIVE MINUTES TODAY:</p>
             <h4 id='steps-friend-active-minutes-average-today'></h4>
@@ -66,12 +68,12 @@
           </div>
         </section>
         <section class='trending-card hide' id='steps-trending-card'>
-          <button type='button' name='button' class='go-back-button steps-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
           <div class='card-data-line trending-steps-phrase-container'>
           </div>
         </section>
         <section class='calendar-card hide' id='steps-calendar-card'>
-          <button type='button' name='button' class='go-back-button steps-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button steps-go-back-button' aria-label='Return To Previous Information'></button>
           <div class='card-data-line'>
             <p>YOUR WEEKLY AVERAGE MINUTES:</p>
             <h4 id='steps-calendar-total-active-minutes-weekly'></h4>
@@ -85,32 +87,34 @@
       <section class='card-container hydration' id='hydration-card-container'>
         <section class='main-card' id='hydration-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button hydration-info-button'></button>
+            <button type='button' name='button' class='info-button hydration-info-button' aria-label='Open Users Hydration Information'></button>
             <h3>YOU HAVE HAD</h3>
-            <button type='button' name='button' class='friends-button hydration-friends-button'></button>
+            <button type='button' name='button' class='friends-button hydration-friends-button' aria-label='Open Friends Hydration Information'></button>
           </div>
           <h2 id='hydration-user-ounces-today'></h2>
           <div class='main-card-bottom-row'>
             <h3>OZ OF WATER TODAY</h3>
-            <button type='button' name='button' class='calendar-button hydration-calendar-button'></button>
+            <button type='button' name='button' class='calendar-button hydration-calendar-button' aria-label='Open Hydration Calendar'> 
+            </button>
           </div>
         </section>
         <section class='info-card hide' id='hydration-info-card'>
-          <button type='button' name='button' class='go-back-button hydration-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'> 
+            </button>
           <div class='card-data-line'>
             <p>GLASSES OF WATER CONSUMED TODAY:</p>
             <h4 id='hydration-info-glasses-today'></h4>
           </div>
         </section>
         <section class='friends-card hide' id='hydration-friends-card'>
-          <button type='button' name='button' class='go-back-button hydration-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>ALL USERS' AVERAGE DAILY OUNCES:</p>
             <h4 id='hydration-friend-ounces-today'></h4>
           </div>
         </section>
         <section class='calendar-card hide' id='hydration-calendar-card'>
-          <button type='button' name='button' class='go-back-button hydration-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button hydration-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='hydration-data-line'>
             <p class='hydration-weekly-label'>YESTERDAY:</p>
             <h4 class='hydration-weekly-amount'><span class='daily-oz' id='hydration-calendar-ounces-1day'></span> oz</h4>
@@ -140,38 +144,38 @@
       <section class='card-container' id='stairs-card-container'>
         <section class='main-card' id='stairs-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button stairs-info-button'></button>
+            <button type='button' name='button' class='info-button stairs-info-button' aria-label='Open Users Stair Count Information'></button>
             <h3>YOU HAVE CLIMBED</h3>
-            <button type='button' name='button' class='friends-button stairs-friends-button'></button>
+            <button type='button' name='button' class='friends-button stairs-friends-button' aria-label='Open Friends Stair Count Information'></button>
           </div>
           <h2 id='stairs-user-stairs-today'></h2>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='trending-button stairs-trending-button'></button>
+            <button type='button' name='button' class='trending-button stairs-trending-button' aria-label='Open Trending Stair Count Information'></button>
             <h3>STAIRS TODAY</h3>
-            <button type='button' name='button' class='calendar-button stairs-calendar-button'></button>
+            <button type='button' name='button' class='calendar-button stairs-calendar-button' aria-label='Open Calendar'></button>
           </div>
         </section>
         <section class='info-card hide' id='stairs-info-card'>
-          <button type='button' name='button' class='go-back-button stairs-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>FLIGHTS CLIMBED TODAY</p>
             <h4 id='stairs-info-flights-today'></h4>
           </div>
         </section>
         <section class='friends-card hide' id='stairs-friends-card'>
-          <button type='button' name='button' class='go-back-button stairs-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>ALL USERS' AVERAGE FLIGHTS TODAY</p>
             <h4 id='stairs-friend-flights-average-today'></h4>
           </div>
         </section>
         <section class='trending-card hide' id='stairs-trending-card'>
-          <button type='button' name='button' class='go-back-button stairs-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line trending-stairs-phrase-container'>
           </div>
         </section>
         <section class='calendar-card hide' id='stairs-calendar-card'>
-          <button type='button' name='button' class='go-back-button stairs-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button stairs-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>YOUR WEEKLY FLIGHTS CLIMBED</p>
             <h4 id='stairs-calendar-flights-average-weekly'></h4>
@@ -185,18 +189,20 @@
       <section class='card-container' id='sleep-card-container'>
         <section class='main-card' id='sleep-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button sleep-info-button'></button>
+            <button type='button' name='button' class='info-button sleep-info-button' aria-label='Open Users Sleep Information'>
+            </button>
             <h3>YOU SLEPT</h3>
-            <button type='button' name='button' class='friends-button sleep-friends-button'></button>
+            <button type='button' name='button' class='friends-button sleep-friends-button' aria-label='Open Friends Sleep Information'>
+            </button>
           </div>
           <h2 id='sleep-user-hours-today'></h2>
           <div class='main-card-bottom-row'>
             <h3>HOURS LAST NIGHT</h3>
-            <button type='button' name='button' class='calendar-button sleep-calendar-button'></button>
+            <button type='button' name='button' class='calendar-button sleep-calendar-button' aria-label='Open Sleep Calendar'></button>
           </div>
         </section>
         <section class='info-card hide' id='sleep-info-card'>
-          <button type='button' name='button' class='go-back-button sleep-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>SLEEP QUALITY LAST NIGHT</p>
             <h4 id='sleep-info-quality-today'></h4>
@@ -211,7 +217,7 @@
           </div>
         </section>
         <section class='friends-card hide' id='sleep-friends-card'>
-          <button type='button' name='button' class='go-back-button sleep-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>LAST NIGHT'S SUPERIOR SLEEPER</p>
             <h4 id='sleep-friend-longest-sleeper'></h4>
@@ -222,7 +228,7 @@
           </div>
         </section>
         <section class='calendar-card hide' id='sleep-calendar-card'>
-          <button type='button' name='button' class='go-back-button sleep-go-back-button'></button>
+          <button type='button' name='button' class='go-back-button sleep-go-back-button' aria-label='Return to Previous Information'></button>
           <div class='card-data-line'>
             <p>LAST WEEK'S HOURLY AVERAGE</p>
             <h4 id='sleep-calendar-hours-average-weekly'></h4>

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang='en'>
   <head>
     <meta charset='UTF-8'>
     <title>Trisha & Kayla's FitLit</title>
@@ -23,9 +23,10 @@
       <section class='card-container' id='steps-card-container'>
         <section class='main-card' id='steps-main-card'>
           <div class='main-card-top-row'>
-            <button type='button' name='button' class='info-button steps-info-button'></button>
+            <button type='button' name='button' class='info-button steps-info-button' aria-label='View User Steps Information' aria-hidden='true'></button> 
+            <!-- aria not working on button above or below  -->
             <h3>YOU HAVE WALKED</h3>
-            <button type='button' name='button' class='friends-button steps-friends-button'></button>
+            <button type='button' name='button' class='friends-button steps-friends-button' aria-label='View Friends Step Button' aria-hidden='true'></button>
           </div>
           <h2 id='steps-user-steps-today'>X</h2>
           <div class='main-card-top-row'>


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features
- [X] Refactoring
- [ ] Planning

### Detailed Description
- Refactored html to improve accessibility 
- You can tab though main view without needing a mouse
- Added aria-labels which describe the purpose of each of the buttons that have no text. These labels can be read by a screen-reader.
- Added an `aria-expanded` attribute to the user profile dropdown box. This needs to be linked to a click-action so I'll add a new issue for this.
- Added the language attribute to the html tag
- Deleted the `type='button'` attribute from each of the buttons as this is redundant information
- I'm not that happy about some of the labels I chose for the buttons but I figure we can improve these once we get more familiar with app and each buttons main use. 
- More work will need to be done to improve accessibility of the information that populates after a button has been selected. 

### Why is this change required? What problem does it solve?
- We started off with a poor accessibility rating of ~30% for the main page
- The accessibility rating is now 100% for the main page

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
- The accessibility audit is only checking the main page view. When we have all the buttons and functionality working I can do the audit on the other sections of the app.
- There are a few `span` attributes in the html that aren't accessible. I will do some research to work out how to make sure the text in/around these spans are accessible.

### Files modified:
- [X] index.html
- [ ] .scss // file name(s):
- [ ] classes // file name(s):
- [ ] test // files name(s):
- [ ] scripts.js
- [ ] Other files:

### Audit results following the changes made in this PR:
<img width="1435" alt="Screen Shot 2020-07-20 at 5 36 09 PM" src="https://user-images.githubusercontent.com/62770843/88000857-f36e2b00-cabb-11ea-9474-b3a7f277b751.png">
